### PR TITLE
Make pyiron& SimStack examples, not obligatory values for workflow environments in meta.json

### DIFF
--- a/docs/pages/detailed_instructions/metadata.md
+++ b/docs/pages/detailed_instructions/metadata.md
@@ -13,7 +13,7 @@ In order to register the workflow in the PMD workflow store, the file `meta.json
 | Key | Requirement | Description|
 |-----|------------|------------|
 | title | Mandatory | the Label of the workflow |
-| workflow_environment | Mandatory | "pyiron" or "SimStack" |
+| workflow_environment | Mandatory | e.g. "pyiron" or "SimStack" |
 | description | Mandatory | the description of the workflow |
 | keywords | Mandatory | a list of (self-chosen) keywords for the workflow |
 | categories | Optional | a list of (self-chosen) categories, e.g., atomistics, continuum, experimental |
@@ -24,7 +24,7 @@ A fully specified `meta.json` has the following format:
 ```json
 {
     "title": "Exciting science experiment",
-    "workflow_environment":"pyiron",
+    "workflow_environment": "pyiron",
     "description": "Code to run new physics",
     "keywords": [
         "workflow",

--- a/docs/pages/user-guide/find-and-download.md
+++ b/docs/pages/user-guide/find-and-download.md
@@ -12,7 +12,7 @@ parent: User Guide
 ### Find and download workflows
 #### Using the website's UI
 - browse the inventory or use the search feature
-- select a workflow you are interested in. *Note that each workflow requires one of the workflow environments supported by the PMD: pyiron or simstack*
+- select a workflow you are interested in.
 - Click on download. You will recieve a zip-archive. Unpack it to your preferred destination.
 
 #### Using the API


### PR DESCRIPTION
In the workflow article we plan to also have participant's use cases, that are not based on the default PMD workflow environments. If that speaks for the Workflow Store and we want to have that workflows in there as well, we need to reflect this in the store doc as well.